### PR TITLE
Fix tooltip wrapping on small equations

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  white-space: nowrap;
   opacity: 0.9;
   transition: opacity 0.2s ease-in-out;
 }


### PR DESCRIPTION
## Purpose of this PR

Fixes an issue where the tooltip text (`"Click to copy"`) could wrap vertically when hovering over very small equations (e.g., a single variable such as `n`).

## Problem

The tooltip is rendered using the `::after` pseudo-element on `.copyable-equation`. For narrow equations, the tooltip text could wrap into multiple lines, causing each character to appear on a separate line and making the tooltip difficult to read.

## Solution

Added:

```css
white-space: nowrap;
```

to the tooltip styles to prevent unintended line breaks and ensure the tooltip remains readable regardless of the equation width.

## Result

* Tooltip text remains on a single line for small equations.
* No visual changes for larger equations.
* Minimal, non-breaking CSS-only fix.

## Screenshots

### Before

<img width="263" height="287" alt="Screenshot 2026-06-10 001903" src="https://github.com/user-attachments/assets/8a91f395-ed65-411b-bbcf-b49afb9e36de" />

### After
<img width="320" height="187" alt="Screenshot 2026-06-10 004824" src="https://github.com/user-attachments/assets/35571643-41ab-44fd-b901-490dd04bedd7" />
